### PR TITLE
Add `"use strict";` statement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,11 @@
+"use strict";
+
 /**
  * This plugin replaces a placeholder string in a given asset with the name of another asset that matches a regex.
  * For example you can replace a <script>/<link> src placeholder in your html with the final name of your js/css asset.
  */
 
 const RawSource = require("webpack/lib/RawSource");
-
 
 class StatsReplacePlugin {
     /**


### PR DESCRIPTION
The `"use strict";` statement removes an error when trying to use this npm package in a Windows environment.
